### PR TITLE
Small cosmetic fixes and one small bug

### DIFF
--- a/adsaws.py
+++ b/adsaws.py
@@ -18,11 +18,11 @@ class AdsAws(BotPlugin):
         :return: the corresponding info
         """
         help = '**ADS AWS Commands**\n'
-        help += '> *!aws ec2info*: get the status of all the ADS AWS EC2 instances\n'
-        help += '> *!aws ec2get*: get the property of an ADS AWS EC2 instance\n'
-        help += '> *!aws ecsclusters*: get a list of ECS clusters with their ARN\n'
-        help += '> *!aws ecsclusterinfo*: get a list of properties for a given ECS cluster\n'
-        help += '> *!aws ecsclusterinfo*: get status info for a given ECS cluster\n'
+        help += '> !aws ec2info*: get the status of all the ADS AWS EC2 instances\n'
+        help += '> !aws ec2get*: get the property of an ADS AWS EC2 instance\n'
+        help += '> !aws ecsclusters*: get a list of ECS clusters with their ARN\n'
+        help += '> !aws ecsclusterinfo*: get a list of properties for a given ECS cluster\n'
+        help += '> !aws ecsclusterinfo*: get status info for a given ECS cluster\n'
         return help
 
     @botcmd
@@ -60,7 +60,7 @@ class AdsAws(BotPlugin):
         return return_msg
 
     @botcmd
-    def aws_ecsclusters(self):
+    def aws_ecsclusters(self, msg, args):
         """
         Return the ARNs for the ECS clusters
         """
@@ -86,10 +86,10 @@ class AdsAws(BotPlugin):
             if entry['clusterName'] != args[0]:
                 continue
             return_msg += '>Status: {}\n'.format(entry['status'])
-            return_msg += '># Registered Container Instances: {}\n'.format(entry['registeredContainerInstancesCount'])
-            return_msg += '># running Tasks: {}\n'.format(entry['runningTasksCount'])
-            return_msg += '># pending Tasks: {}\n'.format(entry['pendingTasksCount'])
-            return_msg += '># active Servies: {}\n'.format(entry['activeServicesCount'])
+            return_msg += '>Number Registered Container Instances: {}\n'.format(entry['registeredContainerInstancesCount'])
+            return_msg += '>Number Running Tasks: {}\n'.format(entry['runningTasksCount'])
+            return_msg += '>Number Pending Tasks: {}\n'.format(entry['pendingTasksCount'])
+            return_msg += '>Number Active Servies: {}\n'.format(entry['activeServicesCount'])
             
         return return_msg
 

--- a/tests/unittests/test_adsaws.py
+++ b/tests/unittests/test_adsaws.py
@@ -98,7 +98,7 @@ class TestAdsAws(unittest.TestCase):
         mock_session.return_value.client.return_value.describe_clusters.return_value = mock_data
         foo = AdsAws()
         return_msg = foo.aws_ecsclusterinfo('ecsclusterinfo','staging')
-        expected   = '**staging**\n>Status: ACTIVE\n># Registered Container Instances: 3\n># running Tasks: 11\n># pending Tasks: 0\n># active Servies: 11\n'
+        expected   = '**staging**\n>Status: ACTIVE\n>Number Registered Container Instances: 3\n>Number Running Tasks: 11\n>Number Pending Tasks: 0\n>Number Active Servies: 11\n'
         self.assertEqual(return_msg, expected)
 
     @patch('adsaws.get_boto3_session')


### PR DESCRIPTION
Cleanup of Help (removal of *), and output that used '#' for 'number'.

The method `aws_ecsclusters` needed three arguments