### PR TITLE
Added templating for Errbot output

### DIFF
--- a/templates/ec2get.html
+++ b/templates/ec2get.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block body %}
+<p style='font-weight:bold'>{{title}}:</p>
+    <table>
+    {% for item in data %}
+	    <tr><td>{{ item.key }}</td><td>{{ item.value }}</td></tr>
+	{% endfor %}
+    </table>
+{% endblock %}

--- a/templates/ec2info.html
+++ b/templates/ec2info.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block body %}
+<p style='font-weight:bold'>ADS AWS EC2 Instances:</p>
+    <table>
+    {% for item in ec2info %}
+	    <tr><td>{{ item.tag }}</td><td>{{ item.status }}</td></tr>
+	{% endfor %}
+    </table>
+{% endblock %}

--- a/templates/ecsclusterinfo.html
+++ b/templates/ecsclusterinfo.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block body %}
+<p style='font-weight:bold'>Information for cluster "{{cluster}}":</p>
+    <table>
+    {% for item in data %}
+	    <tr><td>Status</td><td>{{item.status}}</td></tr>
+		<tr><td># Registered Container Instances</td><td>{{item.instance_num}}</td></tr>
+		<tr><td># Running Tasks</td><td>{{item.running_num}}</td></tr>
+		<tr><td># Pending Tasks</td><td>{{item.pending_num}}</td></tr>
+		<tr><td># Active Tasks</td><td>{{item.active_num}}</td></tr>
+	{% endfor %}
+    </table>
+{% endblock %}

--- a/templates/ecsclusters.html
+++ b/templates/ecsclusters.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block body %}
+<p style='font-weight:bold'>ADS AWS ECS Clusters:</p>
+    <table>
+    {% for item in data %}
+	    <tr><td>{{ item.name }}</td><td>{{ item.ARN }}</td></tr>
+	{% endfor %}
+    </table>
+{% endblock %}

--- a/templates/ecsclusterstatus.html
+++ b/templates/ecsclusterstatus.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block body %}
+<p style='font-weight:bold'>Cluster Container info for: {{cluster}}</p>
+    <table>
+    {% for item in data %}
+	    <tr><td>Container</td><td>{{item.container}}</td></tr>
+		<tr><td>ec2InstanceId</td><td>{{item.ec2InstanceId}}</td></tr>
+		<tr><td>Container status</td><td>{{item.status}}</td></tr>
+		<tr><td>Docker version</td><td>{{item.docker_version}}</td></tr>
+		<tr><td>Agent version</td><td>{{item.agent_num}}</td></tr>
+		<tr><td>Agent connected</td><td>{{item.agent_connected}}</td></tr>
+		<tr><td></td><td></td></tr>
+	{% endfor %}
+    </table>
+{% endblock %}

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block body %}
+<p style='font-weight:bold'>Available Bot Commands:</p>
+    <table>
+    {% for item in commands %}
+	    <tr><td>{{ item.command }}</td><td>{{ item.description }}</td></tr>
+	{% endfor %}
+    </table>
+{% endblock %}

--- a/tests/unittests/test_adsaws.py
+++ b/tests/unittests/test_adsaws.py
@@ -65,12 +65,12 @@ class TestAdsAws(unittest.TestCase):
         self.assertTrue('clusterArns' in info)
 
     @patch('adsaws.get_boto3_session')
-    def test_aws_ecsclusters(self, mock_session):
+    def test_get_aws_ecsclusters(self, mock_session):
         mock_data = {'clusterArns': ['cluster/production','cluster/staging'],'ResponseMetadata': {}}
         mock_session.return_value.client.return_value.list_clusters.return_value = mock_data
         foo = AdsAws()
-        return_msg = foo.aws_ecsclusters()
-        expected   = '**ADS AWS ECS Clusters**\n> production: cluster/production\n> staging: cluster/staging\n'
+        return_msg = foo.aws_ecsclusters('ecsclusters','something')
+        expected   = {'data': [{'name': 'production', 'ARN': 'cluster/production'}, {'name': 'staging', 'ARN': 'cluster/staging'}]}
         self.assertEqual(return_msg, expected)
 
     @patch('adsaws.get_boto3_session')
@@ -98,7 +98,7 @@ class TestAdsAws(unittest.TestCase):
         mock_session.return_value.client.return_value.describe_clusters.return_value = mock_data
         foo = AdsAws()
         return_msg = foo.aws_ecsclusterinfo('ecsclusterinfo','staging')
-        expected   = '**staging**\n>Status: ACTIVE\n>Number Registered Container Instances: 3\n>Number Running Tasks: 11\n>Number Pending Tasks: 0\n>Number Active Servies: 11\n'
+        expected   = {'cluster': 'staging', 'data': [{'status': u'ACTIVE', 'instance_num': 3, 'running_num': 11, 'active_num': 11, 'pending_num': 0}]}
         self.assertEqual(return_msg, expected)
 
     @patch('adsaws.get_boto3_session')
@@ -148,5 +148,5 @@ class TestAdsAws(unittest.TestCase):
         mock_session.return_value.client.return_value.describe_container_instances.return_value = mock_data
         foo = AdsAws()
         return_msg = foo.aws_ecsclusterstatus('ecsclusterstatus', 'staging')
-        expected = '**Cluster Container info for: staging**\n>Container: ARN\n>ec2InstanceId: i-3889f693\n>Container status: ACTIVE\n>Docker version: DockerVersion: 1.6.2\n>Agent version: 1.3.0\n>Agent connected: True\n>+++++++++++++++++++++++++++++++++++++++++++++\n'
+        expected = {'cluster': 'staging', 'data': [{'status': u'ACTIVE', 'container': u'ARN', 'ec2InstanceId': u'i-3889f693', 'docker_version': u'DockerVersion: 1.6.2', 'agent_connected': True, 'agent_version': u'1.3.0'}]}
         self.assertEqual(return_msg, expected)


### PR DESCRIPTION
the output of bot commands are now formatted using jinja2 templates

the command that generates the available commands now auto-detects the commands (= methods with 'bot' decorator)